### PR TITLE
Add folder structure and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ This section hosts various open-source libraries and utilities designed for work
 │   ├── agent_theories/
 │   └── agent_tools/
 └── notebooks/
+    ├── architecture_agents/
+    ├── foundation_models/
+    ├── graph_RAG_systems/
+    ├── agent_theories/
+    ├── agent_tools/
+    ├── data_analysis/
+    ├── model_training/
+    └── visualizations/
 ```
 
 - **/experiments/**: Code and notebooks for testing agentic system prototypes and architectures.

--- a/experiments/LLM_KG_lab/README.md
+++ b/experiments/LLM_KG_lab/README.md
@@ -1,0 +1,27 @@
+# LLM_KG_lab Experiments
+
+Welcome to the `LLM_KG_lab` experiments directory. This folder contains various experiments related to the integration of Large Language Models (LLMs) with Knowledge Graphs (KGs).
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of combining LLMs and KGs, including data integration, knowledge extraction, and reasoning. The goal is to explore and test new approaches to enhance the capabilities of LLMs using structured knowledge from KGs.
+
+## Contents
+
+- **Data Integration:** Experiments with integrating data from various sources into a unified knowledge graph.
+- **Knowledge Extraction:** Experiments with extracting structured knowledge from unstructured text using LLMs.
+- **Reasoning:** Experiments exploring how LLMs can perform reasoning tasks using knowledge graphs.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/experiments/agent_theories/README.md
+++ b/experiments/agent_theories/README.md
@@ -1,0 +1,27 @@
+# Agent Theories Experiments
+
+Welcome to the `agent_theories` experiments directory. This folder contains various experiments related to the theoretical foundations and definitions of agents.
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of agent theories, including agent definitions, classifications, and new paradigms in agent intelligence. The goal is to explore and test new theoretical approaches to understanding and defining agents.
+
+## Contents
+
+- **Agent Definitions:** Experiments with different definitions and conceptualizations of what constitutes an agent.
+- **Agent Classifications:** Experiments with various classification schemes for categorizing agents based on their characteristics and behaviors.
+- **New Paradigms:** Experiments exploring new paradigms and frameworks for understanding agent intelligence and behavior.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/experiments/agent_tools/README.md
+++ b/experiments/agent_tools/README.md
@@ -1,0 +1,27 @@
+# Agent Tools Experiments
+
+Welcome to the `agent_tools` experiments directory. This folder contains various experiments related to the tools and frameworks used for building, managing, and testing agents.
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of agent tools, including libraries, simulators, and benchmarking frameworks. The goal is to explore and test new tools and frameworks to improve the development and evaluation of agents.
+
+## Contents
+
+- **Libraries:** Experiments with various libraries designed to facilitate agent development and management.
+- **Simulators:** Experiments with simulators that provide environments for testing and evaluating agents.
+- **Benchmarking Frameworks:** Experiments with frameworks designed to benchmark the performance and capabilities of agents.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/experiments/architecture_agents/README.md
+++ b/experiments/architecture_agents/README.md
@@ -1,0 +1,27 @@
+# Architecture Agents Experiments
+
+Welcome to the `architecture_agents` experiments directory. This folder contains various experiments related to the design and implementation of agent architectures.
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of agent architectures, including hierarchical agents, modular agents, and emergent systems. The goal is to explore and test new approaches to building and organizing agents to improve their performance and capabilities.
+
+## Contents
+
+- **Hierarchical Agents:** Experiments with agents organized in a hierarchical structure to achieve better coordination and decision-making.
+- **Modular Agents:** Experiments with agents composed of interchangeable modules, allowing for flexible and adaptive behavior.
+- **Emergent Systems:** Experiments exploring how complex behaviors can emerge from simple agent interactions.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/experiments/graph_RAG_systems/README.md
+++ b/experiments/graph_RAG_systems/README.md
@@ -1,0 +1,27 @@
+# Graph RAG Systems Experiments
+
+Welcome to the `graph_RAG_systems` experiments directory. This folder contains various experiments related to the integration of graph structures and Retrieval-Augmented Generation (RAG) systems.
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of combining graph structures and RAG systems, including data retrieval, knowledge representation, and enhanced decision-making. The goal is to explore and test new approaches to improve the efficiency and capabilities of RAG systems using graph-based methods.
+
+## Contents
+
+- **Data Retrieval:** Experiments with efficient data retrieval techniques using graph structures.
+- **Knowledge Representation:** Experiments with representing structured knowledge in graph formats to enhance RAG systems.
+- **Enhanced Decision-Making:** Experiments exploring how graph-based methods can improve decision-making processes in RAG systems.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/experiments/prompty_agent/README.md
+++ b/experiments/prompty_agent/README.md
@@ -1,0 +1,27 @@
+# Prompty Agent Experiments
+
+Welcome to the `prompty_agent` experiments directory. This folder contains various experiments related to the development and testing of prompt-based agents.
+
+## Overview
+
+In this directory, you will find experiments focusing on different aspects of prompt-based agents, including prompt engineering, response generation, and context management. The goal is to explore and test new approaches to improve the performance and capabilities of prompt-based agents.
+
+## Contents
+
+- **Prompt Engineering:** Experiments with different techniques for designing and optimizing prompts to elicit desired responses from agents.
+- **Response Generation:** Experiments with various methods for generating responses based on given prompts and contexts.
+- **Context Management:** Experiments exploring how to effectively manage and utilize context information to enhance agent responses.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the experiments.
+2. **Running Experiments:** Each experiment has its own directory with a `README.md` file containing specific instructions on how to run the experiment.
+3. **Contributing:** If you have new ideas or improvements for the experiments, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any experiments.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/agent_theories/README.md
+++ b/notebooks/agent_theories/README.md
@@ -1,0 +1,27 @@
+# Agent Theories Notebooks
+
+Welcome to the `agent_theories` notebooks directory. This folder contains various Jupyter notebooks related to the theoretical foundations and definitions of agents.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of agent theories, including agent definitions, classifications, and new paradigms in agent intelligence. The goal is to explore and test new theoretical approaches to understanding and defining agents.
+
+## Contents
+
+- **Agent Definitions:** Notebooks with experiments and analyses on different definitions and conceptualizations of what constitutes an agent.
+- **Agent Classifications:** Notebooks with experiments and analyses on various classification schemes for categorizing agents based on their characteristics and behaviors.
+- **New Paradigms:** Notebooks exploring new paradigms and frameworks for understanding agent intelligence and behavior.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/agent_tools/README.md
+++ b/notebooks/agent_tools/README.md
@@ -1,0 +1,27 @@
+# Agent Tools Notebooks
+
+Welcome to the `agent_tools` notebooks directory. This folder contains various Jupyter notebooks related to the tools and frameworks used for building, managing, and testing agents.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of agent tools, including libraries, simulators, and benchmarking frameworks. The goal is to explore and test new tools and frameworks to improve the development and evaluation of agents.
+
+## Contents
+
+- **Libraries:** Notebooks with experiments and analyses on various libraries designed to facilitate agent development and management.
+- **Simulators:** Notebooks with experiments and analyses on simulators that provide environments for testing and evaluating agents.
+- **Benchmarking Frameworks:** Notebooks with experiments and analyses on frameworks designed to benchmark the performance and capabilities of agents.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/architecture_agents/README.md
+++ b/notebooks/architecture_agents/README.md
@@ -1,0 +1,27 @@
+# Architecture Agents Notebooks
+
+Welcome to the `architecture_agents` notebooks directory. This folder contains various Jupyter notebooks related to the design and implementation of agent architectures.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of agent architectures, including hierarchical agents, modular agents, and emergent systems. The goal is to explore and test new approaches to building and organizing agents to improve their performance and capabilities.
+
+## Contents
+
+- **Hierarchical Agents:** Notebooks with experiments and analyses on agents organized in a hierarchical structure to achieve better coordination and decision-making.
+- **Modular Agents:** Notebooks with experiments and analyses on agents composed of interchangeable modules, allowing for flexible and adaptive behavior.
+- **Emergent Systems:** Notebooks exploring how complex behaviors can emerge from simple agent interactions.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/data_analysis/README.md
+++ b/notebooks/data_analysis/README.md
@@ -1,0 +1,27 @@
+# Data Analysis Notebooks
+
+Welcome to the `data_analysis` notebooks directory. This folder contains various Jupyter notebooks related to data analysis tasks.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of data analysis, including data preprocessing, exploratory data analysis (EDA), and statistical analysis. The goal is to provide tools and methods for analyzing and understanding data.
+
+## Contents
+
+- **Data Preprocessing:** Notebooks with experiments and analyses on cleaning, transforming, and preparing data for further analysis.
+- **Exploratory Data Analysis (EDA):** Notebooks with experiments and analyses on exploring data sets to uncover patterns, trends, and insights.
+- **Statistical Analysis:** Notebooks with experiments and analyses on applying statistical methods to analyze data and draw conclusions.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy analyzing!

--- a/notebooks/foundation_models/README.md
+++ b/notebooks/foundation_models/README.md
@@ -1,0 +1,27 @@
+# Foundation Models Notebooks
+
+Welcome to the `foundation_models` notebooks directory. This folder contains various Jupyter notebooks related to foundation models and large language models (LLMs).
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of foundation models, including their architecture, training, and applications. The goal is to explore and test new approaches to building and utilizing these models to improve their performance and capabilities.
+
+## Contents
+
+- **Model Architecture:** Notebooks with experiments and analyses on the design and structure of foundation models.
+- **Training Techniques:** Notebooks exploring various methods and strategies for training large language models.
+- **Applications:** Notebooks examining the use of foundation models in different domains and tasks.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/graph_RAG_systems/README.md
+++ b/notebooks/graph_RAG_systems/README.md
@@ -1,0 +1,27 @@
+# Graph RAG Systems Notebooks
+
+Welcome to the `graph_RAG_systems` notebooks directory. This folder contains various Jupyter notebooks related to the integration of graph structures and Retrieval-Augmented Generation (RAG) systems.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of combining graph structures and RAG systems, including data retrieval, knowledge representation, and enhanced decision-making. The goal is to explore and test new approaches to improve the efficiency and capabilities of RAG systems using graph-based methods.
+
+## Contents
+
+- **Data Retrieval:** Notebooks with experiments and analyses on efficient data retrieval techniques using graph structures.
+- **Knowledge Representation:** Notebooks with experiments and analyses on representing structured knowledge in graph formats to enhance RAG systems.
+- **Enhanced Decision-Making:** Notebooks exploring how graph-based methods can improve decision-making processes in RAG systems.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/model_training/README.md
+++ b/notebooks/model_training/README.md
@@ -1,0 +1,28 @@
+# Model Training Notebooks
+
+Welcome to the `model_training` notebooks directory. This folder contains various Jupyter notebooks related to the training of machine learning models.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of model training, including data preprocessing, model selection, hyperparameter tuning, and evaluation. The goal is to provide a comprehensive set of tools and examples to help you train effective machine learning models.
+
+## Contents
+
+- **Data Preprocessing:** Notebooks with experiments and analyses on preparing and cleaning data for model training.
+- **Model Selection:** Notebooks with experiments and analyses on choosing the right model for your specific task.
+- **Hyperparameter Tuning:** Notebooks exploring various methods and strategies for optimizing model hyperparameters.
+- **Evaluation:** Notebooks examining different techniques for evaluating model performance and ensuring robustness.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy experimenting!

--- a/notebooks/visualizations/README.md
+++ b/notebooks/visualizations/README.md
@@ -1,0 +1,27 @@
+# Visualizations Notebooks
+
+Welcome to the `visualizations` notebooks directory. This folder contains various Jupyter notebooks related to data visualization techniques and tools.
+
+## Overview
+
+In this directory, you will find notebooks focusing on different aspects of data visualization, including creating interactive plots, visualizing complex datasets, and using various visualization libraries. The goal is to explore and demonstrate effective ways to represent data visually to gain insights and communicate findings.
+
+## Contents
+
+- **Interactive Plots:** Notebooks with experiments and examples on creating interactive visualizations using libraries like Plotly, Bokeh, and Altair.
+- **Complex Datasets:** Notebooks with experiments and examples on visualizing complex datasets, including multi-dimensional data and time series.
+- **Visualization Libraries:** Notebooks exploring different visualization libraries and their capabilities, such as Matplotlib, Seaborn, and D3.js.
+
+## Instructions
+
+1. **Setup:** Follow the instructions in the `setup.md` file to set up the necessary environment and dependencies for running the notebooks.
+2. **Running Notebooks:** Each notebook has its own directory with a `README.md` file containing specific instructions on how to run the notebook.
+3. **Contributing:** If you have new ideas or improvements for the notebooks, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required dependencies installed before running any notebooks.
+- Refer to the `setup.md` file for detailed setup instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy visualizing!

--- a/papers/agent_theories/README.md
+++ b/papers/agent_theories/README.md
@@ -1,0 +1,25 @@
+# Agent Theories Papers
+
+Welcome to the `agent_theories` papers directory. This folder contains various research papers related to the theoretical foundations and definitions of agents.
+
+## Overview
+
+In this directory, you will find papers focusing on different aspects of agent theories, including agent definitions, classifications, and new paradigms in agent intelligence. The goal is to explore and understand new theoretical approaches to defining and classifying agents.
+
+## Contents
+
+- **Agent Definitions:** Papers discussing different definitions and conceptualizations of what constitutes an agent.
+- **Agent Classifications:** Papers on various classification schemes for categorizing agents based on their characteristics and behaviors.
+- **New Paradigms:** Papers exploring new paradigms and frameworks for understanding agent intelligence and behavior.
+
+## Instructions
+
+1. **Reading Papers:** Each paper is provided with a summary and relevance to the field of agent theories.
+2. **Contributing:** If you have new papers or improvements to the collection, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure to check the publication date and relevance of each paper.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy reading!

--- a/papers/agent_tools/README.md
+++ b/papers/agent_tools/README.md
@@ -1,0 +1,25 @@
+# Agent Tools Papers
+
+Welcome to the `agent_tools` papers directory. This folder contains various research papers related to the tools and frameworks used for building, managing, and testing agents.
+
+## Overview
+
+In this directory, you will find papers focusing on different aspects of agent tools, including libraries, simulators, and benchmarking frameworks. The goal is to explore and understand new tools and frameworks to improve the development and evaluation of agents.
+
+## Contents
+
+- **Libraries:** Papers discussing various libraries designed to facilitate agent development and management.
+- **Simulators:** Papers on simulators that provide environments for testing and evaluating agents.
+- **Benchmarking Frameworks:** Papers exploring frameworks designed to benchmark the performance and capabilities of agents.
+
+## Instructions
+
+1. **Reading Papers:** Each paper is provided with a summary and relevance to the field of agent tools.
+2. **Contributing:** If you have new papers or improvements to the collection, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure to check the publication date and relevance of each paper.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy reading!

--- a/papers/architecture_agents/README.md
+++ b/papers/architecture_agents/README.md
@@ -1,0 +1,26 @@
+# Architecture Agents Papers
+
+Welcome to the `architecture_agents` papers directory. This folder contains various research papers related to the design and implementation of agent architectures.
+
+## Overview
+
+In this directory, you will find papers focusing on different aspects of agent architectures, including hierarchical agents, modular agents, and emergent systems. The goal is to explore and understand new approaches to building and organizing agents to improve their performance and capabilities.
+
+## Contents
+
+- **Hierarchical Agents:** Papers discussing agents organized in a hierarchical structure to achieve better coordination and decision-making.
+- **Modular Agents:** Papers on agents composed of interchangeable modules, allowing for flexible and adaptive behavior.
+- **Emergent Systems:** Papers exploring how complex behaviors can emerge from simple agent interactions.
+
+## Instructions
+
+1. **Reading Papers:** Each paper has its own directory with a `README.md` file containing specific information about the paper.
+2. **Contributing:** If you have new papers or improvements for the collection, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure that you have the required permissions to access and share the papers.
+- Refer to the `CONTRIBUTING.md` file for detailed contribution instructions.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy reading!

--- a/papers/foundation_models/README.md
+++ b/papers/foundation_models/README.md
@@ -1,0 +1,25 @@
+# Foundation Models Papers
+
+Welcome to the `foundation_models` papers directory. This folder contains various research papers related to foundation models and large language models (LLMs).
+
+## Overview
+
+In this directory, you will find papers focusing on different aspects of foundation models, including their architecture, training, and applications. The goal is to provide a comprehensive collection of research that explores the capabilities and limitations of these models.
+
+## Contents
+
+- **Model Architecture:** Papers discussing the design and structure of foundation models.
+- **Training Techniques:** Papers exploring various methods and strategies for training large language models.
+- **Applications:** Papers examining the use of foundation models in different domains and tasks.
+
+## Instructions
+
+1. **Reading Papers:** Each paper is provided with a summary and relevance to the field of foundation models.
+2. **Contributing:** If you have new papers or improvements to the collection, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure to check the publication date and relevance of each paper.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy reading!

--- a/papers/graph_RAG_systems/README.md
+++ b/papers/graph_RAG_systems/README.md
@@ -1,0 +1,25 @@
+# Graph RAG Systems Papers
+
+Welcome to the `graph_RAG_systems` papers directory. This folder contains various research papers related to the integration of graph structures and Retrieval-Augmented Generation (RAG) systems.
+
+## Overview
+
+In this directory, you will find papers focusing on different aspects of combining graph structures and RAG systems, including data retrieval, knowledge representation, and enhanced decision-making. The goal is to explore and understand new approaches to improve the efficiency and capabilities of RAG systems using graph-based methods.
+
+## Contents
+
+- **Data Retrieval:** Papers discussing efficient data retrieval techniques using graph structures.
+- **Knowledge Representation:** Papers on representing structured knowledge in graph formats to enhance RAG systems.
+- **Enhanced Decision-Making:** Papers exploring how graph-based methods can improve decision-making processes in RAG systems.
+
+## Instructions
+
+1. **Reading Papers:** Each paper is provided with a summary and relevance to the field of graph RAG systems.
+2. **Contributing:** If you have new papers or improvements to the collection, feel free to open a pull request. Make sure to follow the contribution guidelines outlined in the main `CONTRIBUTING.md` file.
+
+## Notes
+
+- Ensure to check the publication date and relevance of each paper.
+- If you encounter any issues or have questions, please reach out to the maintainers.
+
+Happy reading!


### PR DESCRIPTION
Add folder structures and README files for experiments, papers, and notebooks directories.

* **experiments/**: Add subdirectories `architecture_agents`, `LLM_KG_lab`, `graph_RAG_systems`, `agent_theories`, `agent_tools`, and `prompty_agent`. Add README files to each subdirectory providing an overview, contents, instructions, and notes.
* **papers/**: Add subdirectories `architecture_agents`, `foundation_models`, `graph_RAG_systems`, `agent_theories`, and `agent_tools`. Add README files to each subdirectory providing an overview, contents, instructions, and notes.
* **notebooks/**: Add subdirectories `architecture_agents`, `foundation_models`, `graph_RAG_systems`, `agent_theories`, `agent_tools`, `data_analysis`, `model_training`, and `visualizations`. Add README files to each subdirectory providing an overview, contents, instructions, and notes.
* **README.md**: Update the main README file to reflect the new directory structure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Qredence/AgenticFrontier/pull/1?shareId=5a99eab9-3b21-4b00-b996-10e3ea1bcd1c).